### PR TITLE
Add check for missing index parameter to BallCover.R

### DIFF
--- a/R/BallCover.R
+++ b/R/BallCover.R
@@ -1,10 +1,10 @@
 #' Ball Cover
 #'
 #' @docType class
-#' @description This class provides a cover whose open sets are formed by the union of \deqn{\epsilon}-balls centered 
+#' @description This class provides a cover whose open sets are formed by the union of \deqn{\epsilon}-balls centered
 #' about each point. Using this class requires the \code{RANN} package to be installed, and thus explicitly assumes
-#' the filter space endowed with the euclidean metric. 
-#' 
+#' the filter space endowed with the euclidean metric.
+#'
 #' @field epsilon := radius of the ball to form around each point
 #' @author Matt Piekenbrock
 #' @export
@@ -41,33 +41,36 @@ BallCover$set("public", "construct_cover", function(filter, index=NULL){
     stop("Package \"RANN\" is needed for to use this cover.", call. = FALSE)
   }
   self$validate()
-  
-  ## Get filter values 
-  fv <- filter()
-  f_dim <- ncol(fv)
-  f_size <- nrow(fv)
-  
-  ## Construct the balls
-  ball_cover  <- RANN::nn2(fv, query = fv, searchtype = "radius", radius = self$epsilon)
-  
-  ## Union them together 
-  ds <- union_find(f_size)
-  apply(ball_cover$nn.idx, 1, function(idx){
-    connected_idx <- idx[idx != 0] - 1L
-    if (length(connected_idx) > 0){
-      ds$union_all(connected_idx)
-    }
-  })
-  
-  ## Construct the intersections between the open sets and the data
-  cc <- ds$connected_components()
-  self$index_set <- as.character(unique(cc))
-  ls <- lapply(self$index_set, function(idx){
-    which(cc == as.integer(idx))
-  })
-  self$level_sets <- structure(ls, names=self$index_set)
+
+  if(missing(index) || is.null(index)){
+    ## Get filter values
+    fv <- filter()
+    f_dim <- ncol(fv)
+    f_size <- nrow(fv)
+
+    ## Construct the balls
+    ball_cover  <- RANN::nn2(fv, query = fv, searchtype = "radius", radius = self$epsilon)
+
+    ## Union them together
+    ds <- union_find(f_size)
+    apply(ball_cover$nn.idx, 1, function(idx){
+      connected_idx <- idx[idx != 0] - 1L
+      if (length(connected_idx) > 0){
+        ds$union_all(connected_idx)
+      }
+    })
+
+    ## Construct the intersections between the open sets and the data
+    cc <- ds$connected_components()
+    self$index_set <- as.character(unique(cc))
+    ls <- lapply(self$index_set, function(idx){
+      which(cc == as.integer(idx))
+    })
+
+    self$level_sets <- structure(ls, names=self$index_set)
+  }
   if (!missing(index)){ return(self$level_sets[[index]]) }
-  
-  ## Always return self 
+
+  ## Always return self
   invisible(self)
 })


### PR DESCRIPTION
In developing some additional cover options (as discussed in #7), I noticed that level sets were being constructed multiple times per Mapper construction for the BallCover but not the FixedIntervalCover.

This seems to be because FixedIntervalCover only constructs `self$level_sets` when the `index` parameter is missing or null (i.e. when the cover is initially constructed). BallCover does not check whether `index` is null before constructing `self$level_sets`, so the computation may be performed more than once.

Addition of this check for null/missing speeds up BallCover considerably without affecting the level sets or complex that is generated.

For example, using data and filter
```
library(Mapper)

data("noisy_circle", package = "Mapper")
X = noisy_circle

left_pt <- X[which.min(X[, 1]),]
f_X <- matrix(apply(X, 1, function(pt) (pt - left_pt)[1]))
```

I ran the following code using the current version of the `master` branch of Mapper:
```
ptm <- proc.time()
base_m <- MapperRef$new(X)$
  use_filter(filter = f_X)$
  use_cover(cover="ball", epsilon=0.01)$
  use_distance_measure(measure="euclidean")$
  construct_k_skeleton(k=1L)
proc.time()-ptm
```
```
>#   user  system elapsed
     2.09    0.05    2.14
```

Then I ran the same code after loading the current version of this `ballcover_optimization` branch:
```
library(devtools)
load_all()

ptm <- proc.time()
opt_m <- MapperRef$new(X)$
  use_filter(filter = f_X)$
  use_cover(cover="ball", epsilon=0.01)$
  use_distance_measure(measure="euclidean")$
  construct_k_skeleton(k=1L)
proc.time()-ptm
```
```
>#   user  system elapsed
     0.23    0.00    0.19
```

And compared the resulting complexes and level sets:
```
base_levelsets <- base_m$cover$level_sets
base_complex <- base_m$simplicial_complex

optimized_levelsets <- opt_m$cover$level_sets
optimized_complex <- opt_m$simplicial_complex

expect_equal(base_complex, optimized_complex)
expect_identical(base_levelsets, optimized_levelsets)
```

